### PR TITLE
Disable auto correct for phones

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </header>
         <main>
             <h2>Enter any Latin word or sentence</h2>
-            <input type="text" placeholder="Enter any Latin word or sentence here" class="bodyInput" id="lookupInput">
+            <input type="text" autocapitalize="off" autocorrect="off" placeholder="Enter any Latin word or sentence here" class="bodyInput" id="lookupInput">
             <a class="lookupButton" id="lookup" onclick="lookupText($('.bodyInput').val());">Lookup</a>
             <a class="lookupButton red" onclick="window.open('https://en.wiktionary.org/wiki/' + $('.bodyInput').val() + '#Latin');">Not Working? Lookup on Wiktionary</a>
             <div class="results"></div>

--- a/script.js
+++ b/script.js
@@ -162,7 +162,7 @@ function wikiJS(oldWord, language, scrollTo) {
 }
 
 function lookupText(inputText) {
-    inputText = removeDiacritics(inputText);
+    inputText = removeDiacritics(inputText).toLowerCase();
     $('.results').html('');
     let sentence = isSentence(inputText);
     if (sentence == false) {


### PR DESCRIPTION
This (should) disable auto correct and auto capitalization for mobile devices. This will help a lot since often times latin words will be automatically changed to similar English counterparts by default.