### PR TITLE
Fix bug with capital letters, disable auto correct on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </header>
         <main>
             <h2>Enter any Latin word or sentence</h2>
-            <input type="text" placeholder="Enter any Latin word or sentence here" class="bodyInput" id="lookupInput">
+            <input type="text" autocapitalize="off" autocorrect="off" placeholder="Enter any Latin word or sentence here" class="bodyInput" id="lookupInput">
             <a class="lookupButton" id="lookup" onclick="lookupText($('.bodyInput').val());">Lookup</a>
             <a class="lookupButton red" onclick="window.open('https://en.wiktionary.org/wiki/' + $('.bodyInput').val() + '#Latin');">Not Working? Lookup on Wiktionary</a>
             <div class="results"></div>

--- a/script.js
+++ b/script.js
@@ -162,7 +162,7 @@ function wikiJS(oldWord, language, scrollTo) {
 }
 
 function lookupText(inputText) {
-    inputText = removeDiacritics(inputText);
+    inputText = removeDiacritics(inputText).toLowerCase();
     $('.results').html('');
     let sentence = isSentence(inputText);
     if (sentence == false) {


### PR DESCRIPTION
This fixes a bug with capitalization. Currently, using capital letters results in an error. For example:
![Before](https://user-images.githubusercontent.com/62816361/116933750-9a761a80-ac29-11eb-8e51-5d942c8eef5a.gif)

After converting the input text to lower case it works fine:
![after](https://user-images.githubusercontent.com/62816361/116933785-a661dc80-ac29-11eb-8631-26558a2f1881.gif)

I also disabled auto correct and auto capitalization on mobile since Latin probably isn't set as the phone's standard language and can create issues when trying to enter certain words.